### PR TITLE
[FEAT] 주문서 가용 쿠폰 개수 display

### DIFF
--- a/src/components/promotion/coupon/checkout/CheckoutCouponModal.vue
+++ b/src/components/promotion/coupon/checkout/CheckoutCouponModal.vue
@@ -49,7 +49,7 @@ const { isCheckoutCouponModalOpen, orderItems } = defineProps<{
   orderItems: ProductInfo[]
 }>()
 
-const emit = defineEmits(['close-checkout-coupon-modal'])
+const emit = defineEmits(['close-checkout-coupon-modal', 'available-coupons-count'])
 // , {event: 'apply-coupons', null}: void
 
 const computedNestedCoupons = ref<CouponInfoItemCheckoutResponse[][]>([])
@@ -113,6 +113,17 @@ const handleUpdateCoupons = (selectedCoupons: (CouponInfoItemCheckoutResponse | 
   )
 }
 
+const emitAvailableCouponsCount = () => {
+  const distinctCouponInfoIds = new Set(
+    computedNestedCoupons.value
+      .flat()
+      .filter((coupon) => coupon.couponInfoId != null)
+      .map((coupon) => coupon.couponInfoId)
+  )
+
+  emit('available-coupons-count', distinctCouponInfoIds.size)
+}
+
 const applyCouponDatas = () => {
   const updatedProducts = orderItemsWithCouponSelections.value.map((item) => {
     let discount = 0
@@ -139,7 +150,10 @@ const applyCouponDatas = () => {
   productStore.setProducts(updatedProducts, productStore.orderType)
 }
 
-onMounted(fetchCouponsForCheckout)
+onMounted(async () => {
+  await fetchCouponsForCheckout()
+  emitAvailableCouponsCount() // Add this line to update the count after fetching
+})
 </script>
 
 <style scoped>

--- a/src/views/OrderView.vue
+++ b/src/views/OrderView.vue
@@ -60,6 +60,10 @@ const closeCheckoutCouponModal = () => {
   isCheckoutCouponModalOpen.value = false
 }
 
+const changeAvailableCouponsCount = (cnt: number) => {
+  availableCouponsCount.value = cnt
+}
+
 const addDeliveryInfo = async (addressInfo: DeliveryInfo) => {
   deliveryInfo.value.postCode = addressInfo.postCode
   deliveryInfo.value.roadAddress = addressInfo.roadAddress
@@ -156,6 +160,7 @@ onBeforeUnmount(() => {
     :isCheckoutCouponModalOpen="isCheckoutCouponModalOpen"
     :orderItems="products"
     @close-checkout-coupon-modal="closeCheckoutCouponModal"
+    @available-coupons-count="changeAvailableCouponsCount"
   ></CheckoutCouponModal>
   <div class="main-container">
     <h1 v-if="orderType !== 'GIFT'">주문/결제</h1>


### PR DESCRIPTION
## pull request 설명
1. 주문서에 가용쿠폰 개수 보여주는 기능 추가했습니다. api로 받아온 nested array를 flat으로 펴서 couponInfoId의 Set을 만들고 emit으로 넘기는식으로 만들었습니다.

### 변경 사항

- [ ] fix bug
- [ ] add comment
- [ ] add new feature
- [ ] update documents
- [ ] Improvement(refactoring and improving code)
- [ ] etc
