### PR TITLE
[FIX] orderSuccessView로 자식창이 열렸을때 해당 창에서 SSE 구독 안하도록 beforeMount처리

### DIFF
--- a/src/stores/notification/NotificationStore.ts
+++ b/src/stores/notification/NotificationStore.ts
@@ -12,7 +12,8 @@ export const useNotificationStore = defineStore(
   () => {
     const notifications = ref<Notification[]>([])
     const unreadNotificationCount = ref(0)
-    // let unsubscribe: (() => void) | null = null
+    const shouldSubscribeToSSE = ref<boolean>(true)
+
     let eventSourceUnsubscribe: (() => void) | null = null
 
     // 새 알림 가져오기 (unread 최근 5개)
@@ -90,6 +91,13 @@ export const useNotificationStore = defineStore(
 
     const subscribeToNotificationsHandler = () => {
       console.log('subscribeToNotificationsHandler를 발동')
+
+      if (!shouldSubscribeToSSE.value) {
+        // orderSuccessView에서 SSE연결을 하지 않게 제어. 뒤로가기 누를 수 있으니 사이드이펙트 방지용으로 1회성 차단으로 설정
+        shouldSubscribeToSSE.value = true
+        return
+      }
+
       unsubscribeFromNotifications() // 이전 구독이 있다면 해제
 
       const accessToken = localStorage.getItem('accessToken')
@@ -147,6 +155,7 @@ export const useNotificationStore = defineStore(
     return {
       notifications,
       unreadNotificationCount,
+      shouldSubscribeToSSE,
       fetchRecentNotifications,
       fetchAllNotifications,
       fetchUnreadNotificationCount,

--- a/src/views/OrderSuccessView.vue
+++ b/src/views/OrderSuccessView.vue
@@ -3,11 +3,22 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import { onBeforeMount, onMounted, ref } from 'vue'
 import { useRoute } from 'vue-router'
+import { storeToRefs } from 'pinia'
+import { useNotificationStore } from '@/stores/notification/NotificationStore'
+
 const route = useRoute()
 const orderId = ref(route.params.orderId)
+const notificationStore = useNotificationStore()
+const { shouldSubscribeToSSE } = storeToRefs(notificationStore)
 const VITE_SUCCESS_REDIRECT_URL = ref<string>(import.meta.env.VITE_SUCCESS_REDIRECT_URL)
+
+onBeforeMount(() => {
+  // 해당 창에서만 SSE 구독을 차단 (자식창에서 이루어지는 pinia 상태변경은 부모창과 공유되지 않음.)
+  shouldSubscribeToSSE.value = false
+})
+
 onMounted(async () => {
   await window.opener.postMessage(
     {

--- a/src/views/OrderView.vue
+++ b/src/views/OrderView.vue
@@ -11,11 +11,15 @@ import type { DeliveryInfo, OrderSheet, OrderItem, GiftInfo } from '@/apis/order
 import { storeToRefs } from 'pinia'
 import { useProductStore } from '@/stores/product/ProductStore'
 import { useMemberStore } from '@/stores/member/MemberStore'
+import { useNotificationStore } from '@/stores/notification/NotificationStore'
 import router from '@/router'
 import { warningModal } from '@/utils/Modal'
 const productStore = useProductStore()
 const { products, orderType, giftInfo, referralCode } = storeToRefs(productStore)
 const { point } = storeToRefs(useMemberStore())
+
+const notificationStore = useNotificationStore()
+const { shouldSubscribeToSSE } = storeToRefs(notificationStore)
 
 const redirectUrl = ref('')
 const newWindow = ref<any>()
@@ -137,6 +141,7 @@ const validation = (): boolean => {
 const handleMessage = (event: MessageEvent) => {
   const { routeName, params } = event.data
   window.scrollTo(0, 0)
+  shouldSubscribeToSSE.value = true // 리셋
   router.replace({ name: routeName, params: params })
 }
 


### PR DESCRIPTION
## pull request 설명
1. 자식창에서 SSE 구독 안하도록 beforeMount에서 flag 값 바꾸는걸로 처리했습니다.
2. window.open으로 열린 자식창에서 일어난 변화는 부모창에 반영되지 않습니다.

### 변경 사항

- [ ] fix bug
- [ ] add comment
- [ ] add new feature
- [ ] update documents
- [ ] Improvement(refactoring and improving code)
- [ ] etc
