### PR TITLE
[FIX] 알림 구독 관리 pinia, vue life cycle, router에 맞게 재조정

### DIFF
--- a/src/apis/utils/index.ts
+++ b/src/apis/utils/index.ts
@@ -1,5 +1,6 @@
 import axios, { type AxiosInstance, type InternalAxiosRequestConfig } from 'axios'
 import { infoModal } from '@/utils/Modal'
+import { useNotificationStore } from '@/stores/notification/NotificationStore'
 
 const BASE_URL = import.meta.env.VITE_API_BASE_URL
 
@@ -34,106 +35,113 @@ const axiosAuthApi = (baseURL: string) => {
     if (accessToken) {
       config.headers.Authorization = `Bearer ${accessToken}`
     }
-    
 
     return config
   })
 
   instance.interceptors.response.use(
     (response) => {
-      return response;
+      return response
     },
     async (error) => {
-      const originalRequest = error.config;
+      const originalRequest = error.config
 
-      if (error.response && error.response.status === 401 && !originalRequest._retry) {      
-        originalRequest._retry = true;
+      if (error.response && error.response.status === 401 && !originalRequest._retry) {
+        originalRequest._retry = true
 
         try {
-          const newToken = await refreshToken();
+          const newToken = await refreshToken()
 
           if (newToken) {
-            originalRequest.headers.Authorization = `Bearer ${newToken}`;
-            return axios(originalRequest);
+            originalRequest.headers.Authorization = `Bearer ${newToken}`
+            return axios(originalRequest)
           } else {
             // 토큰 갱신 실패 시 로그인 페이지로 리다이렉트 또는 다른 적절한 조치 수행
-            localStorage.clear();
-            showAlert("로그인 정보가 만료되었습니다. 다시 로그인해주세요.(code1)");
-            window.location.href = '/login';
-            return Promise.reject(error);
+            localStorage.clear()
+            showAlert('로그인 정보가 만료되었습니다. 다시 로그인해주세요.(code1)')
+            window.location.href = '/login'
+            return Promise.reject(error)
           }
         } catch (refreshError) {
           // 토큰 갱신 중에 오류가 발생한 경우
-          console.error('Error while refreshing token:', refreshError);
-          return Promise.reject(error);
+          console.error('Error while refreshing token:', refreshError)
+          return Promise.reject(error)
         }
       }
-  
-      return Promise.reject(error);
+
+      return Promise.reject(error)
     }
-  );
-  
+  )
 
   return instance
 }
 
 const refreshToken = async () => {
   try {
-    const memberString = localStorage.getItem('member');
+    const memberString = localStorage.getItem('member')
 
- if (memberString) {
-      const member = JSON.parse(memberString);
-      const memberId = member.memberId;
+    if (memberString) {
+      const member = JSON.parse(memberString)
+      const memberId = member.memberId
 
       const response = await axios.post(
         `${BASE_URL}/auth-service/auth/refresh-token`,
         {
-          accessToken: localStorage.getItem('accessToken'),
+          accessToken: localStorage.getItem('accessToken')
         },
         {
           headers: {
-            'MemberId': memberId,
-          },
+            MemberId: memberId
+          }
         }
-      );
+      )
 
-      const newAccessToken = response.data.accessToken;
+      const newAccessToken = response.data.accessToken
       if (newAccessToken) {
-        delete axios.defaults.headers.common['MemberId'];
-        localStorage.setItem('accessToken', newAccessToken);
-        return newAccessToken;
+        delete axios.defaults.headers.common['MemberId']
+        localStorage.setItem('accessToken', newAccessToken)
+
+        // SSE 연결을 새로고침.
+        const notificationStore = useNotificationStore()
+        notificationStore.unsubscribeFromNotifications() // 기존 구독 해제 (안전을 위해 항상 구독 해제를 시도)
+        notificationStore.subscribeToNotificationsHandler()
+
+        return newAccessToken
       } else {
-        return null;
+        const notificationStore = useNotificationStore()
+        notificationStore.unsubscribeFromNotifications() // 액세스 토큰을 받지 못한 경우 로그인 상태가 유효하지 않으므로 구독 해제
+        return null
       }
     } else {
-      console.error('Member object not found in localStorage');
-      return null;
+      console.error('Member object not found in localStorage')
+      return null
     }
   } catch (error) {
     if (
-      (error as any)?.response?.status === 401 && (error as any)?.response?.data === 'RefreshToken expired'
+      (error as any)?.response?.status === 401 &&
+      (error as any)?.response?.data === 'RefreshToken expired'
     ) {
-      showAlert("로그인 정보가 만료되었습니다. 다시 로그인해주세요.(code2)");
-      window.location.href = '/login';
+      showAlert('로그인 정보가 만료되었습니다. 다시 로그인해주세요.(code2)')
+      window.location.href = '/login'
     } else {
       // 기타 예외 처리
-      console.error('Error:', error);
+      console.error('Error:', error)
     }
   }
-};
+}
 
-let lastAlertTime: number | null = null;
+let lastAlertTime: number | null = null
 
 const showAlert = (message: string): void => {
-  const now: number = Date.now();
-  const timeSinceLastAlert: number = now - (lastAlertTime || 0);
+  const now: number = Date.now()
+  const timeSinceLastAlert: number = now - (lastAlertTime || 0)
 
-  if (lastAlertTime === null || timeSinceLastAlert > 5000) { // 5000ms = 5s
-    infoModal('알림', message);
-    lastAlertTime = now;
+  if (lastAlertTime === null || timeSinceLastAlert > 5000) {
+    // 5000ms = 5s
+    infoModal('알림', message)
+    lastAlertTime = now
   }
-};
-
+}
 
 export const defaultAxiosInstance: AxiosInstance = axiosApi(BASE_URL)
 export const authAxiosInstance: AxiosInstance = axiosAuthApi(BASE_URL)

--- a/src/components/HeaderComponent.vue
+++ b/src/components/HeaderComponent.vue
@@ -25,6 +25,15 @@ const isLoggedIn = () => {
   return !!token
 }
 
+onMounted(() => {
+  if (isLoggedIn()) {
+    // 로그인을 했을때는 router.push로 이동하기 때문에 이 로직이 발동이 안됨. 새로고침시 SSE 재연결하기 위함.
+    notificationStore.subscribeToNotificationsHandler()
+  } else {
+    notificationStore.unsubscribeFromNotifications()
+  }
+})
+
 const showCategoryDropdown = ref<boolean>(true)
 
 const memberInfo = computed(() => memberStore.getMemberInfo())

--- a/src/components/MyPageHeaderComponent.vue
+++ b/src/components/MyPageHeaderComponent.vue
@@ -7,9 +7,12 @@ import { useMemberStore } from '@/stores/member/MemberStore'
 import { useNotificationStore } from '@/stores/notification/NotificationStore'
 import { getMember } from '@/apis/member/member'
 import { successModal, warningModal } from '@/utils/Modal'
+import { storeToRefs } from 'pinia'
+
 const VITE_STATIC_IMG_URL = ref<string>(import.meta.env.VITE_STATIC_IMG_URL)
 const memberStore = useMemberStore()
 const notificationStore = useNotificationStore()
+const { shouldSubscribeToSSE } = storeToRefs(notificationStore)
 const router = useRouter()
 const redirectUrl = ref('')
 const displayModal = ref(false)
@@ -84,6 +87,7 @@ const processPayment = async () => {
   redirectUrl.value = await pointPaymentReady(paymentDto.value)
 
   if (redirectUrl.value) {
+    shouldSubscribeToSSE.value = false
     const width = 500
     const height = 500
     const left = window.screen.width / 2 - width / 2

--- a/src/stores/notification/NotificationStore.ts
+++ b/src/stores/notification/NotificationStore.ts
@@ -12,7 +12,7 @@ export const useNotificationStore = defineStore(
   () => {
     const notifications = ref<Notification[]>([])
     const unreadNotificationCount = ref(0)
-    const shouldSubscribeToSSE = ref<boolean>(true)
+    const shouldSubscribeToSSE = ref<boolean>(true) // order 도중 새로운 창 열릴때 persist의 sessionStorage 공유하기 때문에 연결해제 막아주는 용도
 
     let eventSourceUnsubscribe: (() => void) | null = null
 
@@ -121,36 +121,23 @@ export const useNotificationStore = defineStore(
       )
     }
 
-    // const handleNewNotification = (notificationData: Notification): void => {
-    //   console.log('토스트 알림을 띄웁니다2.')
-    //   notiPopUp.open({
-    //     message: notificationData.message,
-    //     description: '새로운 알림이 도착했습니다.', // Customize as needed
-    //     placement: 'bottomRight',
-    //     duration: 5 // notification will be closed automatically after 5 seconds
-    //   })
-    // }
-
     const clearNotificationForLogout = () => {
       notifications.value = []
       unreadNotificationCount.value = 0
     }
 
-    watch(
-      () => localStorage.getItem('accessToken'),
-      (newToken) => {
-        if (newToken) {
-          // console.log(
-          //   "localStorage.getItem('accessToken') 토큰 변경 감지 subscribeToNotificationsHandler발동 전"
-          // )
-          subscribeToNotificationsHandler()
-        } else {
-          // console.log('토큰이 없어졌음. 구독 해제 직전.')
-          unsubscribeFromNotifications()
-        }
-      },
-      { immediate: true }
-    )
+    // watch(
+    //   () => localStorage.getItem('accessToken'),
+    //   (newToken) => {
+    //     if (newToken) {
+    //       subscribeToNotificationsHandler()
+    //     } else {
+    //       // console.log('토큰이 없어졌음. 구독 해제 직전.')
+    //       unsubscribeFromNotifications()
+    //     }
+    //   },
+    //   { immediate: true }
+    // )
 
     return {
       notifications,
@@ -166,7 +153,6 @@ export const useNotificationStore = defineStore(
       deleteAllNotifs,
       subscribeToNotificationsHandler,
       unsubscribeFromNotifications,
-      // handleNewNotification,
       clearNotificationForLogout
     }
   },

--- a/src/views/LoginGetInfo.vue
+++ b/src/views/LoginGetInfo.vue
@@ -34,6 +34,7 @@ onMounted(async () => {
   } else {
     memberStore.setMemberInfo(memberInfo)
 
+    // 로그인시 구독
     notificationStore.subscribeToNotificationsHandler()
     await notificationStore.fetchUnreadNotificationCount()
     await notificationStore.fetchRecentNotifications()

--- a/src/views/OrderSuccessView.vue
+++ b/src/views/OrderSuccessView.vue
@@ -14,10 +14,11 @@ const notificationStore = useNotificationStore()
 const { shouldSubscribeToSSE } = storeToRefs(notificationStore)
 const VITE_SUCCESS_REDIRECT_URL = ref<string>(import.meta.env.VITE_SUCCESS_REDIRECT_URL)
 
-onBeforeMount(() => {
-  // 해당 창에서만 SSE 구독을 차단 (자식창에서 이루어지는 pinia 상태변경은 부모창과 공유되지 않음.)
-  shouldSubscribeToSSE.value = false
-})
+/*
+해당 창에서만 SSE 구독을 차단 (자식창에서 이루어지는 pinia 상태변경은 부모창과 공유되지 않음.) 
+headerComponent의 onbeforeMount보다 빠른 setup에서 변경 -> 재구독 하지 않음. ( pinia 초기화 -> persist로 sessionStorage물려받음 -> setup -> onBeforeMount )
+*/
+shouldSubscribeToSSE.value = false
 
 onMounted(async () => {
   await window.opener.postMessage(

--- a/src/views/OrderView.vue
+++ b/src/views/OrderView.vue
@@ -118,12 +118,20 @@ const doOrder = async () => {
     const left = window.screen.width / 2 - width / 2
     const top = window.screen.height / 2 - height / 2
 
-    shouldSubscribeToSSE.value = false // 새 창에서 구독로직 차단
     newWindow.value = window.open(
       redirectUrl.value,
       'order',
       `width=${width},height=${height},top=${top},left=${left}`
     )
+
+    if (newWindow.value) {
+      shouldSubscribeToSSE.value = false
+    } else {
+      // 새 창이 차단되었거나 열리지 않았을 경우.
+      // 이 경우 SSE 연결을 활성화.
+      shouldSubscribeToSSE.value = true
+      notificationStore.subscribeToNotificationsHandler()
+    }
   }
 }
 
@@ -142,7 +150,10 @@ const validation = (): boolean => {
 const handleMessage = (event: MessageEvent) => {
   const { routeName, params } = event.data
   window.scrollTo(0, 0)
-  shouldSubscribeToSSE.value = true // 리셋
+
+  shouldSubscribeToSSE.value = true
+  notificationStore.subscribeToNotificationsHandler() // 구독 재활성화
+
   router.replace({ name: routeName, params: params })
 }
 


### PR DESCRIPTION
## pull request 설명
1. 기존 accessToken에 watch를 달아서 알림 구독을 관리하던것에서 로그인, 새로고침, window.open, 로그아웃 라이프사이클을 고려한 알림 구독 관리 로직으로 개선했습니다.
2. pinia persist의 sessionStorage에 shouldSubscribeToSSE flag를 정의해서 window.open으로 자식 창을 열어도 해당 플래그를 물려받을 수 있게 했고, 해당 자식window에서 1회성 알림 구독 차단이 되게 했습니다.

### 변경 사항

- [ ] fix bug
- [ ] add comment
- [ ] add new feature
- [ ] update documents
- [ ] Improvement(refactoring and improving code)
- [ ] etc
